### PR TITLE
Add description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@brnrdog/listbox",
   "version": "2.0.0",
+  "description": "React hooks written in ReScript for building accessible listbox components",
   "repository": "git://github.com/brnrdog/listbox.git",
   "types": "./src/Listbox.d.ts",
   "scripts": {


### PR DESCRIPTION
I am currently building a package index for rescript-lang.org, and since your package doesn't implement a description field, it will show the first lines of your README instead, which is a blob of markdown:

![image](https://user-images.githubusercontent.com/1121889/98210011-31df0700-1f40-11eb-9cd1-9d626e852189.png)

This patch will make sure to show a one line description instead.